### PR TITLE
Update to 1.0.0-beta2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM phusion/baseimage:0.9.15
+FROM phusion/baseimage:latest
 MAINTAINER Tudor Golubenco <tudor@packetbeat.com>
 
 RUN apt-get update
-RUN apt-get -y -q install libpcap0.8
+RUN apt-get -y -q install libpcap0.8 wget
 
-RUN curl -L -o /tmp/packetbeat_0.3.3-1_amd64.deb https://github.com/packetbeat/packetbeat/releases/download/v0.3.3/packetbeat_0.3.3-1_amd64.deb
-RUN dpkg -i /tmp/packetbeat_0.3.3-1_amd64.deb
-ADD packetbeat.conf /etc/packetbeat/packetbeat.conf
+ENV VERSION=1.0.0-beta2 ARCH=x86_64 EXTENSION=tar.gz
+ENV FILENAME=packetbeat-${VERSION}-${ARCH}.${EXTENSION}
+
+RUN wget https://download.elastic.co/beats/packetbeat/${FILENAME}
+RUN tar zxvf ${FILENAME}
+
+WORKDIR packetbeat-${VERSION}
+ADD packetbeat.yml packetbeat.yml
+
+CMD ["./packetbeat", "-e", "-c=packetbeat.yml"]


### PR DESCRIPTION
This image is not being tagged yet for different versions which make it harder to use out-of-the-box, but people will be able to use it as a basic copy/paste if they want to run another version.
